### PR TITLE
Update for AIRAC 2102

### DIFF
--- a/openflightmaps/openflightmaps.dgml
+++ b/openflightmaps/openflightmaps.dgml
@@ -25,7 +25,7 @@
           <tileSize width="512" height="512" />
           <storageLayout levelZeroColumns="1" levelZeroRows="1" maximumTileLevel="19" mode="Custom" />
           <projection name="Mercator" />
-          <downloadUrl protocol="https" host="nwy-tiles-api.prod.newaydata.com" path="/tiles/{zoomLevel}/{x}/{y}.jpg" query="path=2101/base/latest" />
+          <downloadUrl protocol="https" host="nwy-tiles-api.prod.newaydata.com" path="/tiles/{zoomLevel}/{x}/{y}.jpg" query="path=2102/base/latest" />
           <downloadPolicy usage="Browse" maximumConnections="20" />
           <downloadPolicy usage="Bulk" maximumConnections="2" />
         </texture>
@@ -34,7 +34,7 @@
           <tileSize width="512" height="512" />
           <storageLayout levelZeroColumns="1" levelZeroRows="1" maximumTileLevel="19" mode="Custom" />
           <projection name="Mercator" />
-          <downloadUrl protocol="https" host="nwy-tiles-api.prod.newaydata.com" path="/tiles/{zoomLevel}/{x}/{y}.png" query="path=2101/aero/latest" />
+          <downloadUrl protocol="https" host="nwy-tiles-api.prod.newaydata.com" path="/tiles/{zoomLevel}/{x}/{y}.png" query="path=2102/aero/latest" />
           <blending name="OverpaintBlending" />
         </texture>
       </layer>


### PR DESCRIPTION
Changed the file to use the 2102 URL, wich is used by the fullscreen webviewer, too. Now includes traffic circuits in a few locations.