### PR TITLE
Always use current AIRAC, changes/optimizations

### DIFF
--- a/openflightmaps/openflightmaps.dgml
+++ b/openflightmaps/openflightmaps.dgml
@@ -11,31 +11,33 @@
       <description><![CDATA[<p>High quality VFR maps provided by the open flightmaps association (OFMA).</p>]]></description>
       <icon pixmap="openflightmaps-preview.jpg"/>
       <zoom>
-        <discrete> true </discrete>
-        <minimum> 1950 </minimum>
-        <maximum> 2770 </maximum>
+        <discrete>true</discrete>
+        <minimum>900</minimum>
+        <maximum>3500</maximum>
       </zoom>
     </head>
     <map bgcolor="#000000">
       <canvas/>
       <target/>
       <layer name="openflightmaps" backend="texture">
-        <texture name="map" expire="1209600" >
-          <sourcedir format="JPG"> earth/openflightmaps </sourcedir>
-          <tileSize width="512" height="512" />
-          <storageLayout levelZeroColumns="1" levelZeroRows="1" maximumTileLevel="19" mode="Custom" />
-          <projection name="Mercator" />
-          <downloadUrl protocol="https" host="nwy-tiles-api.prod.newaydata.com" path="/tiles/{zoomLevel}/{x}/{y}.jpg" query="path=2205/base/latest" />
-          <downloadPolicy usage="Browse" maximumConnections="20" />
-          <downloadPolicy usage="Bulk" maximumConnections="2" />
+        <texture name="base" expire="1209600">
+          <sourcedir format="JPG">earth/openflightmaps</sourcedir>
+          <tileSize width="512" height="512"/>
+          <storageLayout levelZeroColumns="1" levelZeroRows="1" minimumTileLevel="7" maximumTileLevel="12" mode="Custom"/>
+          <projection name="Mercator"/>
+          <downloadUrl protocol="https" host="nwy-tiles-api.prod.newaydata.com" path="/tiles/{zoomLevel}/{x}/{y}.jpg" query="path=latest/base/latest"/>
+          <downloadPolicy usage="Browse" maximumConnections="20"/>
+          <downloadPolicy usage="Bulk" maximumConnections="2"/>
         </texture>
-        <texture name="aero" expire="1209600" >
-          <sourcedir format="PNG"> earth/openflightmaps/aero </sourcedir>
-          <tileSize width="512" height="512" />
-          <storageLayout levelZeroColumns="1" levelZeroRows="1" maximumTileLevel="19" mode="Custom" />
-          <projection name="Mercator" />
-          <downloadUrl protocol="https" host="nwy-tiles-api.prod.newaydata.com" path="/tiles/{zoomLevel}/{x}/{y}.png" query="path=2205/aero/latest" />
-          <blending name="OverpaintBlending" />
+        <texture name="aero" expire="1209600">
+          <sourcedir format="PNG">earth/openflightmaps/aero</sourcedir>
+          <tileSize width="512" height="512"/>
+          <storageLayout levelZeroColumns="1" levelZeroRows="1" minimumTileLevel="7" maximumTileLevel="12" mode="Custom"/>
+          <projection name="Mercator"/>
+          <downloadUrl protocol="https" host="nwy-tiles-api.prod.newaydata.com" path="/tiles/{zoomLevel}/{x}/{y}.png" query="path=latest/aero/latest"/>
+          <downloadPolicy usage="Browse" maximumConnections="20"/>
+          <downloadPolicy usage="Bulk" maximumConnections="2"/>
+          <blending name="OverpaintBlending"/>
         </texture>
       </layer>
     </map>


### PR DESCRIPTION
- Always use the last AIRAC with "/latest/base/latest" path.
- Use a less restrictive zoom to allow view of the airport layout.
- Adjust minimum and maximum tile level to prevent fetching of
  unavailable tiles.
- Add download policy for aero tiles as well, since I'm unsure if it is
  picked up.

It's a bit of a mess with quite some changes so feedback is encouraged but I had those changes lying around for some time. :slightly_smiling_face: 